### PR TITLE
[codex] Remove unsafe Polyfill.io references from generated docs

### DIFF
--- a/docs/assign-grnas.html
+++ b/docs/assign-grnas.html
@@ -118,7 +118,7 @@ div.csl-indent {
     "search-submit-button-title": "Submit",
     "search-label": "Search"
   }
-}</script><script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
+}</script><script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
 const typesetMath = (el) => {
   if (window.MathJax) {
     // MathJax Typeset

--- a/docs/methods.html
+++ b/docs/methods.html
@@ -91,7 +91,7 @@ div.csl-indent {
   }
 }</script>
 
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script>
 
 <script type="text/javascript">

--- a/docs/run-calibration-check.html
+++ b/docs/run-calibration-check.html
@@ -118,7 +118,7 @@ div.csl-indent {
     "search-submit-button-title": "Submit",
     "search-label": "Search"
   }
-}</script><script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
+}</script><script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
 const typesetMath = (el) => {
   if (window.MathJax) {
     // MathJax Typeset

--- a/docs/run-qc.html
+++ b/docs/run-qc.html
@@ -118,7 +118,7 @@ div.csl-indent {
     "search-submit-button-title": "Submit",
     "search-label": "Search"
   }
-}</script><script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
+}</script><script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
 const typesetMath = (el) => {
   if (window.MathJax) {
     // MathJax Typeset

--- a/docs/sceptre.html
+++ b/docs/sceptre.html
@@ -118,7 +118,7 @@ div.csl-indent {
     "search-submit-button-title": "Submit",
     "search-label": "Search"
   }
-}</script><script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
+}</script><script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
 const typesetMath = (el) => {
   if (window.MathJax) {
     // MathJax Typeset

--- a/docs/set-analysis-parameters.html
+++ b/docs/set-analysis-parameters.html
@@ -118,7 +118,7 @@ div.csl-indent {
     "search-submit-button-title": "Submit",
     "search-label": "Search"
   }
-}</script><script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
+}</script><script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script><script type="text/javascript">
 const typesetMath = (el) => {
   if (window.MathJax) {
     // MathJax Typeset


### PR DESCRIPTION
## Summary

Replaces generated-site references to `https://polyfill.io/v3/polyfill.min.js?features=es6` with Cloudflare's Polyfill mirror in the six affected HTML pages under `docs/`.

## Why

The current GitHub Pages site loads JavaScript from `polyfill.io`, which was affected by a 2024 supply-chain incident and can trigger browser security/authentication prompts. These references appear to have been emitted by the Quarto 1.4.549-generated HTML when MathJax is enabled.

This is a narrow generated-docs patch so the currently published GitHub Pages site stops calling `polyfill.io`. A future full re-render should use Quarto >= 1.4.557, or a current Quarto release, so the unsafe URL is not regenerated.

## Validation

- `grep -RInE "polyfill\.io|cdn\.polyfill\.io" docs || true` returns no matches.
- Local dirty-clone comparison still reproduces the vulnerable page from `/Users/ekatsevi/code/research/sceptre-book/docs`.
- Browser spot-check: served the dirty clone on localhost and confirmed the affected page path before testing the fixed worktree separately.